### PR TITLE
fixed relative path

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,7 @@ tasks:
 
   - name: Compose Setup
     init: cd demo && docker-compose --env-file env pull
-    command: cd demo && docker-compose --env-file env up
+    command: docker-compose --env-file env up
   
   - name: Readyness Check
     init: ./demo/check-dashboards.sh


### PR DESCRIPTION
Signed-off-by: Kyle J. Davis <kyledvs@amazon.com>

### Description
Fixed issue with gitpod going to `demo/demo` instead of `demo` in compose  

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
