### PR TITLE
Added bulk ingestion of data into OpenSearch API

### DIFF
--- a/demo/docbot/ingestion.py
+++ b/demo/docbot/ingestion.py
@@ -27,7 +27,7 @@ def read_files_from_data() -> list:
   all_json = [f for f in os.listdir(DATA_PATH) if f.endswith('.json')]
 
   if not all_json:
-    raise FileNotFoundError("Cannot find JSON files in /demos/data")
+    raise FileNotFoundError("Failed to find JSON files in /demos/data")
 
   for file in all_json:
       path = os.path.join(DATA_PATH, file)
@@ -39,12 +39,22 @@ def read_files_from_data() -> list:
 
   return result
 
-def ingest_to_opensearch(data):
-  # client = opensearch_connection_builder()
-  # client.bulk()
-  pass
+def ingest_to_opensearch(data) -> int:
+  client = opensearch_connection_builder()
+  docs = []
+  for point in range(len(data)):
+    docs.append({"index": {"_index": "docbot", "_id": point}})
+    docs.append(json.dumps(data_list[point]))
+
+  response = client.bulk(docs)
+  if response["errors"]:
+    raise ValueError("Failed to insert data into client.")
+  else:
+    print(f"Bulk-inserted {len(response['items'])} items.")
+
+  return 1
 
 if __name__=="__main__":
   # do ingestions
   data_list = read_files_from_data()
-  print(data_list)
+  ingest_to_opensearch(data_list)


### PR DESCRIPTION
### Description
This adds ingest_to_opensearch function which bulk ingests data into opensearch api.

### Issues Resolved
This solves [#37](https://github.com/opensearch-project/demos/issues/37)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
