### PR TITLE
Implemented Env defaults & created try-except block

### DIFF
--- a/demo/docbot/cluster_bootstrap.py
+++ b/demo/docbot/cluster_bootstrap.py
@@ -229,17 +229,19 @@ def initialize_ingestion_pipeline(client: MLClient):
     }
 
     # Check if the pipeline already exists
-    existing_pipeline = client._client.ingest.get_pipeline(id="cohere-ingest-pipeline")
-    if not existing_pipeline.equals("") or existing_pipeline is not None:
-        print("Pipeline 'cohere-ingest-pipeline' already exists. Skipping initialization.")
-        return
+    try:
+        existing_pipeline = client._client.ingest.get_pipeline(id="cohere-ingest-pipeline")
+        if not existing_pipeline.equals("") or existing_pipeline is not None:
+            print("Pipeline 'cohere-ingest-pipeline' already exists. Skipping initialization.")
+            return
+    except:
+        response = client._client.ingest.put_pipeline(id="cohere-ingest-pipeline", body=pipeline_data)
 
-    response = client._client.ingest.put_pipeline(id="cohere-ingest-pipeline", body=pipeline_data)
-
-    if response and 'acknowledged' in response and response['acknowledged']:
-        print("Pipeline 'cohere-ingest-pipeline' initialized successfully!")
-    else:
-        raise Exception("Failed to initialize pipeline.")
+        if response and 'acknowledged' in response and response['acknowledged']:
+            print("Pipeline 'cohere-ingest-pipeline' initialized successfully!")
+        else:
+            raise Exception("Failed to initialize pipeline.")
+        pass
 
 
 
@@ -292,7 +294,10 @@ def initialize_index(client: MLClient) -> None:
 
 def main():
     try:
-        client = opensearch_connection_builder(ml_client=True)
+        use_ssl = True
+        if "--no-ssl" in sys.argv:
+            use_ssl = False
+        client = opensearch_connection_builder(ml_client=True, use_ssl=use_ssl)
         initialize_cluster_settings(client)
         initialize_model_group(client)
         initialize_connector(client)

--- a/demo/docbot/util.py
+++ b/demo/docbot/util.py
@@ -189,7 +189,7 @@ class MLClient(MLCommonClient):
 
 ##### END MONKEYPATCH #####
 
-def opensearch_connection_builder(ml_client=False, use_ssl=True):
+def opensearch_connection_builder(ml_client=False, use_ssl=True) -> MLCommonClient | OpenSearch:
   config = {
     "hosts": HOSTS,
     "http_auth": (ADMIN_UN, ADMIN_PW),

--- a/demo/docbot/util.py
+++ b/demo/docbot/util.py
@@ -5,12 +5,13 @@ from opensearch_py_ml.ml_commons import MLCommonClient
 from copy import deepcopy
 
 
-dotenv.load_dotenv()
-ADMIN_PW = getenv('ADMIN_PW')
-ADMIN_UN = getenv('ADMIN_UN')
-HOSTS = getenv('HOSTS')
-DEVELOPMENT= getenv('DEVELOPMENT')
+if (not dotenv.load_dotenv()):
+  print("No .env file found. Loading defaults...")
 
+ADMIN_PW = 'admin' if getenv('ADMIN_PW') == None else getenv('ADMIN_PW')
+ADMIN_UN = 'admin' if getenv('ADMIN_UN') == None else getenv('ADMIN_UN')
+HOSTS = 'localhost:9200' if getenv('HOSTS') == None else getenv('HOSTS')
+DEVELOPMENT= True if getenv('DEVELOPMENT') == None else getenv('DEVELOPMENT')
 
 ##### Monkey patching 🤪 #####
 
@@ -188,11 +189,11 @@ class MLClient(MLCommonClient):
 
 ##### END MONKEYPATCH #####
 
-def opensearch_connection_builder(ml_client=False) -> MLCommonClient | OpenSearch:
+def opensearch_connection_builder(ml_client=False, use_ssl=True):
   config = {
     "hosts": HOSTS,
     "http_auth": (ADMIN_UN, ADMIN_PW),
-    "use_ssl": True,
+    "use_ssl": use_ssl,
     "verify_certs": True
   }
 
@@ -213,10 +214,10 @@ def opensearch_connection_builder(ml_client=False) -> MLCommonClient | OpenSearc
 def opensearch_compare_dictionaries(value1, value2):
     if type(value1) != type(value2):
         return False
-    
+
     if isinstance(value1, (int, float, str, bool)):
         return value1 is value2 if isinstance(value1, bool) else value1 == value2
-    
+
     if isinstance(value1, list):
         if len(value1) != len(value2):
             return False
@@ -224,7 +225,7 @@ def opensearch_compare_dictionaries(value1, value2):
             if not opensearch_compare_dictionaries(item1, item2):
                 return False
         return True
-    
+
     if isinstance(value1, dict):
         if set(value1.keys()) != set(value2.keys()):
             return False
@@ -232,7 +233,7 @@ def opensearch_compare_dictionaries(value1, value2):
             if not opensearch_compare_dictionaries(value1[key], value2[key]):
                 return False
         return True
-    
+
     return False
 
 


### PR DESCRIPTION
### Description
This change allows users to pass in an optional --no-ssl argument when calling cluster_bootstrap.py. If the optional argument is passed, use_ssl is set to false when configuring the ML client. It also implements default values for environment variables for the ML client if a .env file is not found. It also adds a try-except block in cluster_boostrap.py for more robustness.

### Issues Resolved
This solves issue #41.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
