### PR TITLE
Add methods for search pipeline endpoints

### DIFF
--- a/demo/docbot/util.py
+++ b/demo/docbot/util.py
@@ -222,6 +222,20 @@ class MLClient(MLCommonClient):
          url=_make_path("_search", "pipeline", id),
          body=body
       )
+  
+  def delete_search_pipeline(self, id: str) -> None:
+      """
+      Deletes search pipeline
+
+      :param id: Pipeline id
+      :type id: string
+      :return: returns json object if request was successful
+      :rtype: object
+      """
+      return self._client.transport.perform_request(
+         method="DELETE",
+         url=_make_path("search", "pipeline", id)
+      )
 
 ##### END MONKEYPATCH #####
 

--- a/demo/docbot/util.py
+++ b/demo/docbot/util.py
@@ -187,7 +187,7 @@ class MLClient(MLCommonClient):
           method="DELETE",
           url=API_URL,
       )
-  
+
   def get_search_pipeline(self, id=None) -> dict:
       """
       Returns search pipeline if it exists
@@ -199,7 +199,7 @@ class MLClient(MLCommonClient):
       """
       return self._client.transport.perform_request(
          method="GET",
-         url=_make_path("_search", "pipeline", id),
+         url=_make_path("_search", "pipeline", id)
       )
 
   def put_search_pipeline(self, id: str, body : dict) -> dict:
@@ -216,7 +216,7 @@ class MLClient(MLCommonClient):
       for param in (id, body):
             if param in SKIP_IN_PATH:
                 raise ValueError("Empty value passed for a required argument.")
-      
+
       return self._client.transport.perform_request(
          method="PUT",
          url=_make_path("_search", "pipeline", id),

--- a/demo/docbot/util.py
+++ b/demo/docbot/util.py
@@ -202,7 +202,7 @@ class MLClient(MLCommonClient):
          url=_make_path("_search", "pipeline", id)
       )
 
-  def put_search_pipeline(self, id: str, body : dict) -> dict:
+  def put_search_pipeline(self, id: str, body: dict) -> dict:
       """
       Creates or updates search pipeline
 
@@ -222,7 +222,7 @@ class MLClient(MLCommonClient):
          url=_make_path("_search", "pipeline", id),
          body=body
       )
-  
+
   def delete_search_pipeline(self, id: str) -> None:
       """
       Deletes search pipeline
@@ -234,7 +234,7 @@ class MLClient(MLCommonClient):
       """
       return self._client.transport.perform_request(
          method="DELETE",
-         url=_make_path("search", "pipeline", id)
+         url=_make_path("_search", "pipeline", id)
       )
 
 ##### END MONKEYPATCH #####

--- a/demo/docbot/util.py
+++ b/demo/docbot/util.py
@@ -21,6 +21,7 @@ from opensearch_py_ml.ml_commons.ml_common_utils import (
 )
 from typing import Union, Any
 from datetime import time
+from opensearchpy.client.utils import SKIP_IN_PATH, _make_path
 
 
 class MLClient(MLCommonClient):
@@ -185,6 +186,41 @@ class MLClient(MLCommonClient):
       return self._client.transport.perform_request(
           method="DELETE",
           url=API_URL,
+      )
+  
+  def get_search_pipeline(self, id=None) -> dict:
+      """
+      Returns search pipeline if it exists
+
+      :param id: Id of pipeline to be retrieved
+      :type id: string
+      :return: returns json object, if pipeline exists
+      :rtype: object
+      """
+      return self._client.transport.perform_request(
+         method="GET",
+         url=_make_path("_search", "pipeline", id),
+      )
+
+  def put_search_pipeline(self, id: str, body : dict) -> dict:
+      """
+      Creates or updates search pipeline
+
+      :param id: Pipeline id
+      :type id: string
+      :param body: body of search pipeline request
+      :type body: dict
+      :return: returns json object if request was successful
+      :rtype: object
+      """
+      for param in (id, body):
+            if param in SKIP_IN_PATH:
+                raise ValueError("Empty value passed for a required argument.")
+      
+      return self._client.transport.perform_request(
+         method="PUT",
+         url=_make_path("_search", "pipeline", id),
+         body=body
       )
 
 ##### END MONKEYPATCH #####


### PR DESCRIPTION
### Description
Added method to perform request on `PUT /_search/pipeline/<id>` endpoint as well as the `GET /_search/pipeline/<id>` and `DELETE /_search/pipeline/<id>` endpoints

### Issues Resolved
Resolves #93 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
