### PR TITLE
Implement function to initialize rag search pipeline

### DIFF
--- a/demo/docbot/cluster_bootstrap.py
+++ b/demo/docbot/cluster_bootstrap.py
@@ -255,7 +255,7 @@ def initialize_rag_search_pipeline(client: MLClient, id: str = "rag-search-pipel
           "retrieval_augmented_generation": {
             "description": "RAG search pipeline to be used with Cohere index",
             "model_id": MODEL_STATE["LLM_model_id"],
-            "context_field_list": ["text"]
+            "context_field_list": ["content"]
           }
         }
       ]


### PR DESCRIPTION
### Description
Adds method to initialize the RAG search pipeline as well as making it the default for the `cohere-index`.

### Issues Resolved
Resolves #82 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
