### PR TITLE
Added pre-commit type-checking

### DIFF
--- a/demo/docbot/.pre-commit-config.yaml
+++ b/demo/docbot/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.6.1
+  hooks:
+  - id: mypy


### PR DESCRIPTION
### Description
Added pre-commit type-checking using mypy.
Written by Mekaeel and Miriam

### Issues Resolved
This contributes to issue #92, but we still need to verify that all types are working. It clearly shows issues for cluster-bootstrapping.py which need to be addressed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
