### PR TITLE
Add example of running OpenSearch-Dashboards configured with LDAP and basic auth

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,72 @@
+# OpenSearch + OpenSearch Dashboards with OpenLDAP authentication backend
+
+This repo provides an example cluster using OpenLDAP as an authentication backend.
+
+## Services
+
+- OpenSearch node (Port: 9200)
+- OpenSearch Dashboards (Port: 5601)
+- OpenLDAP
+- PhpLDAPAdmin (Port: 6443)
+
+## Start the cluster
+
+Clone this repository and navigate to the cloned repo using a terminal.
+
+In the root directory of this project run `docker-compose down && docker-compose up` to start a cluster.
+
+### Making changes in LDAP
+
+Login to PhpLDAPAdmin (https://localhost:6443) using the admin account.
+
+- Username: cn=admin,dc=example,dc=org
+- Password: changethis
+
+You can make changes in the directory as the admin
+
+## Default accounts
+
+This repo comes with some default accounts listed in `directory.ldif`
+
+
+When logging into OpenSearch Dashboards you can use the common name (cn), but you need to use the distinguished name (dn) when logging into PhpLDAPAdmin
+
+
+```
+dn: cn=jroe,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: top
+cn: jroe
+userpassword: password
+givenname: Jane
+sn: Roe
+mail: jroe@example.org
+uid: 1001
+
+dn: cn=jdoe,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: top
+cn: jdoe
+userpassword: password
+givenname: John
+sn: Doe
+mail: jdoe@example.org
+uid: 1002
+
+dn: cn=psmith,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: top
+cn: psmith
+userpassword: password
+givenname: Paul
+sn: Smith
+mail: psmith@example.org
+uid: 1003
+```
+

--- a/demo/config/opensearch-security/config.yml
+++ b/demo/config/opensearch-security/config.yml
@@ -1,0 +1,71 @@
+---
+_meta:
+  type: "config"
+  config_version: 2
+
+config:
+  dynamic:
+    http:
+      anonymous_auth_enabled: false
+    authc:
+      internal_auth:
+        order: 0
+        description: "HTTP basic authentication using the internal user database"
+        http_enabled: true
+        transport_enabled: true
+        http_authenticator:
+          type: basic
+          challenge: false
+        authentication_backend:
+          type: internal
+      ldap_auth:
+        order: 1
+        description: "Authenticate using LDAP"
+        http_enabled: true
+        transport_enabled: false
+        http_authenticator:
+          type: basic
+          challenge: false
+        authentication_backend:
+          type: ldap
+          config:
+            enable_ssl: false
+            enable_start_tls: false
+            enable_ssl_client_auth: false
+            verify_hostnames: false
+            hosts:
+            - openldap:389
+            bind_dn: cn=readonly,dc=example,dc=org
+            password: changethistoo
+            userbase: ou=People,dc=example,dc=org
+            usersearch: (cn={0})
+            username_attribute: cn
+
+    authz:
+      ldap_roles:
+        description: "Authorize using LDAP"
+        http_enabled: true
+        transport_enabled: false
+        authorization_backend:
+          type: ldap
+          config:
+            enable_ssl: false
+            enable_start_tls: false
+            enable_ssl_client_auth: false
+            verify_hostnames: true
+            hosts:
+            - openldap:389
+            bind_dn: cn=readonly,dc=example,dc=org
+            password: changethistoo
+            userbase: ou=People,dc=example,dc=org
+            usersearch: (cn={0})
+            username_attribute: cn
+            skip_users:
+              - admin
+              - kibanaserver
+            rolebase: ou=Groups,dc=example,dc=org
+            rolesearch: (uniqueMember={0})
+            userroleattribute: null
+            userrolename: disabled
+            rolename: cn
+            resolve_nested_roles: false

--- a/demo/config/opensearch-security/internal_users.yml
+++ b/demo/config/opensearch-security/internal_users.yml
@@ -1,0 +1,19 @@
+---
+# This is the internal user database
+# The hash value is a bcrypt hash and can be generated with plugin/tools/hash.sh
+
+_meta:
+  type: "internalusers"
+  config_version: 2
+
+admin:
+  hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
+  reserved: true
+  backend_roles:
+  - "admin"
+  description: "Demo admin user"
+
+kibanaserver:
+  hash: "$2a$12$4AcgAt3xwOWadA5s5blL6ev39OXDNhmOesEoo33eZtrq2N0YrU3H."
+  reserved: true
+  description: "Demo kibanaserver user"

--- a/demo/config/opensearch-security/roles_mapping.yml
+++ b/demo/config/opensearch-security/roles_mapping.yml
@@ -1,0 +1,42 @@
+---
+
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+
+all_access:
+  reserved: false
+  backend_roles:
+  - "admin"
+  - "Administrator"
+  description: "Maps admin to all_access"
+
+own_index:
+  reserved: false
+  users:
+  - "*"
+  description: "Allow full access to an index named like the username"
+
+kibana_user:
+  reserved: false
+  backend_roles:
+  - "kibanauser"
+  - "Developers"
+  description: "Maps kibanauser to kibana_user"
+
+readall:
+  reserved: false
+  backend_roles:
+  - "readall"
+  - "Developers"
+
+manage_snapshots:
+  reserved: false
+  backend_roles:
+  - "snapshotrestore"
+  - "Developers"
+
+kibana_server:
+  reserved: true
+  users:
+  - "kibanaserver"

--- a/demo/config/opensearch_dashboards.yml
+++ b/demo/config/opensearch_dashboards.yml
@@ -1,0 +1,210 @@
+---
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Description:
+# Default configuration for OpenSearch Dashboards
+
+# OpenSearch Dashboards is served by a back end server. This setting specifies the port to use.
+# server.port: 5601
+
+# Specifies the address to which the OpenSearch Dashboards server will bind. IP addresses and host names are both valid values.
+# The default is 'localhost', which usually means remote machines will not be able to connect.
+# To allow connections from remote users, set this parameter to a non-loopback address.
+# server.host: "localhost"
+
+# Enables you to specify a path to mount OpenSearch Dashboards at if you are running behind a proxy.
+# Use the `server.rewriteBasePath` setting to tell OpenSearch Dashboards if it should remove the basePath
+# from requests it receives, and to prevent a deprecation warning at startup.
+# This setting cannot end in a slash.
+# server.basePath: ""
+
+# Specifies whether OpenSearch Dashboards should rewrite requests that are prefixed with
+# `server.basePath` or require that they are rewritten by your reverse proxy.
+# server.rewriteBasePath: false
+
+# The maximum payload size in bytes for incoming server requests.
+# server.maxPayloadBytes: 1048576
+
+# The OpenSearch Dashboards server's name.  This is used for display purposes.
+# server.name: "your-hostname"
+
+# The URLs of the OpenSearch instances to use for all your queries.
+# opensearch.hosts: ["http://localhost:9200"]
+
+# OpenSearch Dashboards uses an index in OpenSearch to store saved searches, visualizations and
+# dashboards. OpenSearch Dashboards creates a new index if the index doesn't already exist.
+# opensearchDashboards.index: ".opensearch_dashboards"
+
+# The default application to load.
+# opensearchDashboards.defaultAppId: "home"
+
+# Setting for an optimized healthcheck that only uses the local OpenSearch node to do Dashboards healthcheck.
+# This settings should be used for large clusters or for clusters with ingest heavy nodes.
+# It allows Dashboards to only healthcheck using the local OpenSearch node rather than fan out requests across all nodes.
+#
+# It requires the user to create an OpenSearch node attribute with the same name as the value used in the setting
+# This node attribute should assign all nodes of the same cluster an integer value that increments with each new cluster that is spun up
+# e.g. in opensearch.yml file you would set the value to a setting using node.attr.cluster_id:
+# Should only be enabled if there is a corresponding node attribute created in your OpenSearch config that matches the value here
+# opensearch.optimizedHealthcheckId: "cluster_id"
+
+# If your OpenSearch is protected with basic authentication, these settings provide
+# the username and password that the OpenSearch Dashboards server uses to perform maintenance on the OpenSearch Dashboards
+# index at startup. Your OpenSearch Dashboards users still need to authenticate with OpenSearch, which
+# is proxied through the OpenSearch Dashboards server.
+# opensearch.username: "opensearch_dashboards_system"
+# opensearch.password: "pass"
+
+# Enables SSL and paths to the PEM-format SSL certificate and SSL key files, respectively.
+# These settings enable SSL for outgoing requests from the OpenSearch Dashboards server to the browser.
+# server.ssl.enabled: false
+# server.ssl.certificate: /path/to/your/server.crt
+# server.ssl.key: /path/to/your/server.key
+
+# Optional settings that provide the paths to the PEM-format SSL certificate and key files.
+# These files are used to verify the identity of OpenSearch Dashboards to OpenSearch and are required when
+# xpack.security.http.ssl.client_authentication in OpenSearch is set to required.
+# opensearch.ssl.certificate: /path/to/your/client.crt
+# opensearch.ssl.key: /path/to/your/client.key
+
+# Optional setting that enables you to specify a path to the PEM file for the certificate
+# authority for your OpenSearch instance.
+# opensearch.ssl.certificateAuthorities: [ "/path/to/your/CA.pem" ]
+
+# To disregard the validity of SSL certificates, change this setting's value to 'none'.
+# opensearch.ssl.verificationMode: full
+
+# Time in milliseconds to wait for OpenSearch to respond to pings. Defaults to the value of
+# the opensearch.requestTimeout setting.
+# opensearch.pingTimeout: 1500
+
+# Time in milliseconds to wait for responses from the back end or OpenSearch. This value
+# must be a positive integer.
+# opensearch.requestTimeout: 30000
+
+# List of OpenSearch Dashboards client-side headers to send to OpenSearch. To send *no* client-side
+# headers, set this value to [] (an empty list).
+# opensearch.requestHeadersWhitelist: [ authorization ]
+
+# Header names and values that are sent to OpenSearch. Any custom headers cannot be overwritten
+# by client-side headers, regardless of the opensearch.requestHeadersWhitelist configuration.
+# opensearch.customHeaders: {}
+
+# Time in milliseconds for OpenSearch to wait for responses from shards. Set to 0 to disable.
+# opensearch.shardTimeout: 30000
+
+# Logs queries sent to OpenSearch. Requires logging.verbose set to true.
+# opensearch.logQueries: false
+
+# Specifies the path where OpenSearch Dashboards creates the process ID file.
+# pid.file: /var/run/opensearchDashboards.pid
+
+# Enables you to specify a file where OpenSearch Dashboards stores log output.
+# logging.dest: stdout
+
+# Set the value of this setting to true to suppress all logging output.
+# logging.silent: false
+
+# Set the value of this setting to true to suppress all logging output other than error messages.
+# logging.quiet: false
+
+# Set the value of this setting to true to log all events, including system usage information
+# and all requests.
+# logging.verbose: false
+
+# Set the interval in milliseconds to sample system and process performance
+# metrics. Minimum is 100ms. Defaults to 5000.
+# ops.interval: 5000
+
+# Specifies locale to be used for all localizable strings, dates and number formats.
+# Supported languages are the following: English - en , by default , Chinese - zh-CN .
+# i18n.locale: "en"
+
+# Set the allowlist to check input graphite Url. Allowlist is the default check list.
+# vis_type_timeline.graphiteAllowedUrls: ['https://www.hostedgraphite.com/UID/ACCESS_KEY/graphite']
+
+# Set the blocklist to check input graphite Url. Blocklist is an IP list.
+# Below is an example for reference
+# vis_type_timeline.graphiteBlockedIPs: [
+#  //Loopback
+#  '127.0.0.0/8',
+#  '::1/128',
+#  //Link-local Address for IPv6
+#  'fe80::/10',
+#  //Private IP address for IPv4
+#  '10.0.0.0/8',
+#  '172.16.0.0/12',
+#  '192.168.0.0/16',
+#  //Unique local address (ULA)
+#  'fc00::/7',
+#  //Reserved IP address
+#  '0.0.0.0/8',
+#  '100.64.0.0/10',
+#  '192.0.0.0/24',
+#  '192.0.2.0/24',
+#  '198.18.0.0/15',
+#  '192.88.99.0/24',
+#  '198.51.100.0/24',
+#  '203.0.113.0/24',
+#  '224.0.0.0/4',
+#  '240.0.0.0/4',
+#  '255.255.255.255/32',
+#  '::/128',
+#  '2001:db8::/32',
+#  'ff00::/8',
+# ]
+# vis_type_timeline.graphiteBlockedIPs: []
+
+# opensearchDashboards.branding:
+#   logo:
+#     defaultUrl: ""
+#     darkModeUrl: ""
+#   mark:
+#     defaultUrl: ""
+#     darkModeUrl: ""
+#   loadingLogo:
+#     defaultUrl: ""
+#     darkModeUrl: ""
+#   faviconUrl: ""
+#   applicationTitle: ""
+
+# Set the value of this setting to true to capture region blocked warnings and errors
+# for your map rendering services.
+# map.showRegionBlockedWarning: false%
+
+# Set the value of this setting to false to suppress search usage telemetry
+# for reducing the load of OpenSearch cluster.
+# data.search.usageTelemetry.enabled: false
+
+# 2.4 renames 'wizard.enabled: false' to 'vis_builder.enabled: false'
+# Set the value of this setting to false to disable VisBuilder
+# functionality in Visualization.
+# vis_builder.enabled: false
+
+# 2.4 New Experimental Feature
+# Set the value of this setting to true to enable the experimental multiple data source
+# support feature. Use with caution.
+# data_source.enabled: false
+# Set the value of these settings to customize crypto materials to encryption saved credentials
+# in data sources.
+# data_source.encryption.wrappingKeyName: 'changeme'
+# data_source.encryption.wrappingKeyNamespace: 'changeme'
+# data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+
+# 2.6 New ML Commons Dashboards Feature
+# Set the value of this setting to true to enable the ml commons dashboards
+# ml_commons_dashboards.enabled: false
+
+opensearch.hosts: [https://host.docker.internal:9200]
+opensearch.ssl.verificationMode: none
+opensearch.username: kibanaserver
+opensearch.password: kibanaserver
+opensearch.requestHeadersWhitelist: [authorization, securitytenant]
+
+opensearch_security.multitenancy.enabled: true
+opensearch_security.multitenancy.tenants.preferred: [Private, Global]
+opensearch_security.readonly_mode.roles: [kibana_read_only]
+# Use this setting if you are running opensearch-dashboards without https
+opensearch_security.cookie.secure: false
+server.host: '0.0.0.0'

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       node.name: opensearch
       OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
     volumes:
+      - ./config/opensearch-security/config.yml:/usr/share/opensearch/config/opensearch-security/config.yml
+      - ./config/opensearch-security/internal_users.yml:/usr/share/opensearch/config/opensearch-security/internal_users.yml
+      - ./config/opensearch-security/roles_mapping.yml:/usr/share/opensearch/config/opensearch-security/roles_mapping.yml
       - opensearch-data:/usr/share/opensearch/data
     ports:
       - 9200:9200
@@ -25,10 +28,38 @@ services:
       - "5601"
     environment:
       OPENSEARCH_HOSTS: '["https://opensearch:9200"]'
+    volumes:
+      - ./config/opensearch_dashboards.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml
     networks:
       - opensearch-net
     depends_on:
       - opensearch
+
+  openldap:
+    image: osixia/openldap
+    container_name: openldap
+    command: --copy-service # seemingly required to load directory.ldif
+    ports:
+      - 389:389
+      - 636:636
+    environment:
+      - LDAP_ADMIN_PASSWORD=changethis
+      - LDAP_READONLY_USER=true
+      - LDAP_READONLY_USER_PASSWORD=changethistoo
+    volumes:
+      - ./ldap_config/directory.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/directory.ldif
+    networks:
+      - opensearch-net
+
+  openldap-admin:
+    image: osixia/phpldapadmin
+    container_name: openldap-admin
+    ports:
+      - 6443:443
+    environment:
+      - PHPLDAPADMIN_LDAP_HOSTS=openldap
+    networks:
+      - opensearch-net
 
 volumes:
   opensearch-data:

--- a/demo/ldap_config/directory.ldif
+++ b/demo/ldap_config/directory.ldif
@@ -1,0 +1,69 @@
+# --- OUs -------------------------------------
+
+dn: ou=Groups,dc=example,dc=org
+objectClass: organizationalunit
+objectClass: top
+ou: Groups
+
+dn: ou=People,dc=example,dc=org
+objectClass: organizationalunit
+objectClass: top
+ou: People
+
+
+# --- People ----------------------------------
+
+dn: cn=jroe,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: top
+cn: jroe
+userpassword: password
+givenname: Jane
+sn: Roe
+mail: jroe@example.org
+uid: 1001
+
+dn: cn=jdoe,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: top
+cn: jdoe
+userpassword: password
+givenname: John
+sn: Doe
+mail: jdoe@example.org
+uid: 1002
+
+dn: cn=psmith,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: top
+cn: psmith
+userpassword: password
+givenname: Paul
+sn: Samith
+mail: psmith@example.org
+uid: 1003
+
+
+# --- Groups ----------------------------------
+
+dn: cn=Administrator,ou=Groups,dc=example,dc=org
+objectClass: groupofuniquenames
+objectClass: top
+ou: Groups
+cn: Administrator
+uniquemember: cn=psmith, ou=People, dc=example,dc=org
+
+dn: cn=Developers,ou=Groups,dc=example,dc=org
+objectClass: groupofuniquenames
+objectClass: top
+ou: Groups
+cn: Developers
+uniquemember: cn=psmith, ou=People, dc=example,dc=org
+uniquemember: cn=jroe, ou=People, dc=example,dc=org
+uniquemember: cn=jdoe, ou=People, dc=example,dc=org


### PR DESCRIPTION
### Description

Adds an example where the security plugin is configured to authenticate with an external LDAP backend. The docker-compose file in this example includes 2 services in addition to OpenSearch and OSD. They are: OpenLDAP and an admin panel to interactively explore the directory and make changes. 

There is a README to accompany this PR that includes instructions on how to login with LDAP and OpenSearch Dashboards. There are 3 example users in this PR with different backend roles.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

^ I plan to open an issue to track all security examples. I will update this description with a link once opened. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
