### PR TITLE
Adds pyproject.toml for YAPF linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 
 # yapf can be installed using 'pip install yapf'
 [tool.yapf]
+column_limit = 100
 based_on_style = "pep8"
 indent_width = 2
 continuation_indent_width = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+# pyproject.toml
+
+# yapf can be installed using 'pip install yapf'
+[tool.yapf]
+based_on_style = "pep8"
+indent_width = 2
+continuation_indent_width = 2
+join_multiple_lines = true
+indent_dictionary_value = true
+coalesce_brackets = true
+each_dict_entry_on_separate_line = true
+align_closing_bracket_with_visual_indent = true


### PR DESCRIPTION
### Description
This change adds configuration settings for the YAPF linter in a new pyproject.toml file stored at the root of the repo. YAPF (Yet Another Python Formatter) is an open-source Python linter that automatically reformats code based on the style standard chosen in the config settings and also allows for more customization, such as changing the indent space size. Currently, the pyproject.toml configuration adopts the PEP 8 style guide, ensuring codebase consistency and readability. It customizes formatting with a 2-space indentation, a 100-character line limit, and specific style settings for brackets and dictionaries, enhancing structure and visual clarity.

### Issues Resolved
Aims to reolve #94

PS. Black was not chosen as it doesnt support 2 space indents. PyLint and Flake8 were not chosen as they are just style checkers and don't automatically format code for you. YAPF seemed to be the better option out of all of them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).