### PR TITLE
Adds a pre-commit hook for running YAPF

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,9 @@ repos:
     rev: v2.1.0
     hooks:
         -   id: docker-compose-check
+
+-   repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.31.0  # Replace with the desired version of YAPF
+    hooks:
+      - id: yapf
+        files: \.py$


### PR DESCRIPTION
### Description
Adds a pre-commit hook for running YAPF on every .py file committed.

### Issues Resolved
aims to relove #96 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
